### PR TITLE
Change to absolute class path in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ If you want to selectively cache only specific requests to your site, you should
 
 ```php
 protected $routeMiddleware = [
-    'page-cache' => Silber\PageCache\Middleware\CacheResponse::class,
+    'page-cache' => \Silber\PageCache\Middleware\CacheResponse::class,
     /* ... keep the existing mappings here */
 ];
 ```


### PR DESCRIPTION
If I don't use the absolute path I get the following error: 'Class App\Http\Silber\PageCache\Middleware\CacheResponse does not exist'