### PR TITLE
Support for Laravel 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "silber/page-cache",
-    "description": "Caches responses as static files on disk for lightning fast page loads..",
+    "description": "Caches responses as static files on disk for lightning fast page loads.",
     "keywords": [
         "laravel",
         "cache"

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/contracts": "^5.0|^6.0",
-        "illuminate/filesystem": "^5.0|^6.0",
+        "illuminate/contracts": "^5.5|^6.0",
+        "illuminate/filesystem": "^5.5|^6.0",
         "symfony/http-foundation": "2.6 - 4"
     },
     "require-dev": {
-        "illuminate/container": "^5.0|^6.0",
+        "illuminate/container": "^5.5|^6.0",
         "larapack/dd": "^1.1",
         "mockery/mockery": "^0.9.5",
         "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/contracts": "5.0 - 5.8",
-        "illuminate/filesystem": "5.0 - 5.8",
+        "illuminate/contracts": "^5.0|^6.0",
+        "illuminate/filesystem": "^5.0|^6.0",
         "symfony/http-foundation": "2.6 - 4"
     },
     "require-dev": {
-        "illuminate/container": "5.0 - 5.8",
+        "illuminate/container": "^5.0|^6.0",
         "larapack/dd": "^1.1",
         "mockery/mockery": "^0.9.5",
         "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
     "name": "silber/page-cache",
     "description": "Caches responses as static files on disk for lightning fast page loads..",
-    "keywords": ["laravel", "cache"],
+    "keywords": [
+        "laravel",
+        "cache"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -9,14 +12,6 @@
             "email": "contact@josephsilber.com"
         }
     ],
-    "autoload": {
-        "psr-4": {
-            "Silber\\PageCache\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "classmap": ["tests"]
-    },
     "require": {
         "php": ">=5.5.9",
         "illuminate/contracts": "5.0 - 5.8",
@@ -38,5 +33,15 @@
                 "Silber\\PageCache\\LaravelServiceProvider"
             ]
         }
+    },
+    "autoload": {
+        "psr-4": {
+            "Silber\\PageCache\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests"
+        ]
     }
 }


### PR DESCRIPTION
Added support for Laravel 6.0
Release scheduled for September 3rd , 2019 (https://laravel.com/docs/6.0/releases).

Dropped support for Laravel < 5.5.
5.5 is the latest LTS release.