### PR TITLE
Drop support for PHP 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,19 @@
 language: php
 
 php:
-  - 5.5.9
   - 5.6
   - 7.0
 
-env:
-  global:
-    - setup=basic
-
-matrix:
-  include:
-    - php: 5.5.9
-      env: setup=lowest
-    - php: 5.5.9
-      env: setup=stable
-
 sudo: false
 
-install:
-  - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-source; fi
-  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-stable; fi
-  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-lowest --prefer-stable; fi
+env:
+  matrix:
+    - COMPOSER_FLAGS="--prefer-lowest"
+    - COMPOSER_FLAGS=""
 
-script: vendor/bin/phpunit
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+
+script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "classmap": ["tests"]
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.6",
         "illuminate/contracts": "5.0 - 5.8",
         "illuminate/filesystem": "5.0 - 5.8",
         "symfony/http-foundation": "2.6 - 4"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "classmap": ["tests"]
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "illuminate/contracts": "5.0 - 5.8",
         "illuminate/filesystem": "5.0 - 5.8",
         "symfony/http-foundation": "2.6 - 4"


### PR DESCRIPTION
Laravel 5.5 requires PHP >= 7.0.
Dropped support for PHP 5. See PR #43 .