### PR TITLE
Enable .json file extension for json responses

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ In order to serve the static files directly once they've been cached, you need t
     }
 
     location / {
-        try_files $uri $uri/ /page-cache/$uri.html /index.php?$query_string;
+        try_files $uri $uri/ /page-cache/$uri.html /page-cache/$uri.json /index.php?$query_string;
     }
     ```
 
@@ -104,6 +104,8 @@ In order to serve the static files directly once they've been cached, you need t
     RewriteRule .? page-cache/pc__index__pc.html [L]
     RewriteCond %{DOCUMENT_ROOT}/page-cache%{REQUEST_URI}.html -f
     RewriteRule . page-cache%{REQUEST_URI}.html [L]
+    RewriteCond %{DOCUMENT_ROOT}/page-cache%{REQUEST_URI}.json -f
+    RewriteRule . page-cache%{REQUEST_URI}.json [L]
     ```
 
 ### Ignoring the cached files


### PR DESCRIPTION
To automatically set the correct content-type for application/json responses, check if the response is a JsonResponse and if so, create a .json file instead of a .html file.

I didn't write a test since I didn't know where to start to be honest.

It is not perfect since the ending "json" is hardcoded but in the future, the determineFileExtension method could be extended if needed.

Also, the forget method is not the most elegant with trying to delete either a .html or a .json file. If you have a better idea on how to solve that, please let me know and I'll try to rewrite it. I've chosen this way since at least in my applications, it's always either a html or json response which would benefit the most from the caching.

Cheers!