### PR TITLE
Added XML extension for Cache::forget method

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -172,8 +172,9 @@ class Cache
     {
         $deletedHtml = $this->files->delete($this->getCachePath($slug.'.html'));
         $deletedJson = $this->files->delete($this->getCachePath($slug.'.json'));
+        $deletedXml = $this->files->delete($this->getCachePath($slug.'.xml'));
 
-        return $deletedHtml || $deletedJson;
+        return $deletedHtml || $deletedJson || $deletedXml;
     }
 
     /**


### PR DESCRIPTION
I added .xml extension for clear cache. used on /rss.xml or /sitemap.xml