### PR TITLE
Fix cache if URL has trailing slash

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -197,7 +197,7 @@ class Cache
      */
     protected function getDirectoryAndFileNames($request, $response)
     {
-        $segments = explode('/', ltrim($request->getPathInfo(), '/'));
+        $segments = explode('/', trim($request->getPathInfo(), '/'));
 
         $filename = $this->aliasFilename(array_pop($segments));
         $extension = $this->guessFileExtension($response);


### PR DESCRIPTION
If the URL ends with a slash the explode contains an empty element at the end. 

```php
$segments = explode('/', ltrim($request->getPathInfo(), '/'));
```

Simple fix changing `ltrim` to `trim` 

e.g: https://example.com/about-us/
VS: https://example.com/about-us
> page-cache/about-us.html 
> page-cache/about-us/pc__index__pc.html 

Nginx/apache will never read the latter. 

Fixes issue: https://github.com/JosephSilber/page-cache/issues/35