### PR TITLE
Remove the extension from the filename

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -202,6 +202,10 @@ class Cache
         $filename = $this->aliasFilename(array_pop($segments));
         $extension = $this->guessFileExtension($response);
 
+        // Remove the extension from the filename
+        // example: Route::get('manifest.json') -> manifest
+        $filename = str_replace('.' . $extension, '', $filename);
+
         $file = "{$filename}.{$extension}";
 
         return [$this->getCachePath(implode('/', $segments)), $file];


### PR DESCRIPTION
Remove the extension from the filename to route with extension file. Example: Route::get('manifest.json')